### PR TITLE
Fixed findDicomName to support keys in query

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "dicom-parser": "^1.8.13",
     "fastify": "^4.10.2",
     "shelljs": "^0.8.5",
-    "simple-node-logger": "^21.8.12"
+    "simple-node-logger": "^21.8.12",
+    "fs-walk": "^0.0.2"
   },
   "devDependencies": {
     "eslint": "^8.23.0",

--- a/src/storescu.js
+++ b/src/storescu.js
@@ -2,12 +2,13 @@
 const dimse = require('dicom-dimse-native');
 const config = require('config');
 const path = require('path');
+const walk = require('fs-walk');
 
 const j = {};
 j.source = config.get('source');
 j.target = j.source;
-j.sourcePath = path.join(__dirname, '../import');
 j.verbose = true;
+j.sourcePath = path.join(__dirname, '../import');
 dimse.storeScu(j, result => {
   if (result && result.length > 0) {
     try {
@@ -15,5 +16,20 @@ dimse.storeScu(j, result => {
     } catch (e) {
       console.error(e, result);
     }
+  }
+});
+
+walk.walkSync(path.join(__dirname,'../import'), function(basedir, filename, stat) {
+  if (stat.isDirectory()) {
+    j.sourcePath = basedir;
+    dimse.storeScu(j, result => {
+      if (result && result.length > 0) {
+        try {
+          console.log(JSON.parse(result));
+        } catch (e) {
+          console.error(e, result);
+        }
+      }
+    });
   }
 });

--- a/src/utils.js
+++ b/src/utils.js
@@ -27,7 +27,7 @@ const findDicomName = (name) => {
   // eslint-disable-next-line no-restricted-syntax
   for (const key of Object.keys(dict.standardDataElements)) {
     const value = dict.standardDataElements[key];
-    if (value.name === name) {
+    if ((value.name === name) || (name === key)) {
       return key;
     }
   }


### PR DESCRIPTION
Minor fix to findDicomName.  When looking in the standardDataElements dictionary to find the key for a given name, if either the value or the key matches the name, the key should be returned.  